### PR TITLE
Add array adapter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is unreleased software. I commit backwards incompatible changes without not
 
 ### Adapters
 Then choose from two storage adapters:
-APCu is the default option. Redis can also be used.
+APCu is the default option. Redis can also be used. There's also `array` available for testing.
 
 #### APCu
 Ensure apcu-bc is installed and enabled.


### PR DESCRIPTION
This adds support for an array adapter. My usecase is a unit-test that is failing on my local machine because I don't have either extension installed and don't want to install them. I want to be able to configure an array adapter for unit-tests and call it a day.